### PR TITLE
Update VS Code settings and CMakeLists for DMDRVI module integration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
     "files.associations": {
         "dmfsi.h": "c"
-    }
+    },
+    "C_Cpp.default.compileCommands": "${workspaceFolder}/build/compile_commands.json",
+    "C_Cpp.intelliSenseEngine": "default",
+    "C_Cpp.errorSquiggles": "enabled"
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,10 @@
 # =====================================================================
 cmake_minimum_required(VERSION 3.18)
 
+# ======================================================================
+#               For VS Code
+# ======================================================================
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # ======================================================================
 #               dmdrvi Version
@@ -71,6 +75,10 @@ set(DMOD_STACK_SIZE         1024)
 dmod_add_library(${DMOD_MODULE_NAME} ${DMOD_MODULE_VERSION}
     # List of source files - can include C and C++ files
     src/dmdrvi.c
+)
+
+dmod_link_modules(${DMOD_MODULE_NAME}
+    dmini
 )
 
 target_include_directories(${DMOD_MODULE_NAME} PRIVATE

--- a/include/dmdrvi.h
+++ b/include/dmdrvi.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include "dmod.h"
 #include "dmdrvi_defs.h"
+#include "dmini.h"
 
 /**
  * @brief Opaque context type for DMDRVI module
@@ -56,7 +57,7 @@ typedef struct
  * 
  * @return dmdrvi_context_t Created DMDRVI context
  */
-dmod_dmdrvi_dif(1.0, dmdrvi_context_t, _create, ( void* config, const dmdrvi_dev_num_t* dev_num ));
+dmod_dmdrvi_dif(1.0, dmdrvi_context_t, _create, ( dmini_context_t config, const dmdrvi_dev_num_t* dev_num ));
 
 /**
  * @brief Free a DMDRVI context


### PR DESCRIPTION
This pull request introduces improvements for VS Code integration, updates to the build system, and refactors the DMDRVI module to depend on the `dmini` module. The changes enhance the development experience in VS Code, ensure proper linking between modules, and update the DMDRVI API to use the `dmini_context_t` type.

**VS Code and Build System Integration:**

* Enabled generation of `compile_commands.json` for better code navigation and IntelliSense in VS Code by setting `CMAKE_EXPORT_COMPILE_COMMANDS ON` in `CMakeLists.txt` and configuring related settings in `.vscode/settings.json`. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR6-R9) [[2]](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L4-R7)

**Module Dependency and API Refactoring:**

* Added `dmini.h` as an include in `dmdrvi.h` and updated the `dmdrvi_context_create` API to accept a `dmini_context_t` instead of a generic pointer, clarifying the dependency between DMDRVI and DMINI. [[1]](diffhunk://#diff-e4000e683065b513b333297ca58c85074599b54744332f5c7a94153707ba3e97R7) [[2]](diffhunk://#diff-e4000e683065b513b333297ca58c85074599b54744332f5c7a94153707ba3e97L59-R60)
* Linked the `dmini` module to the `dmdrvi` target using `dmod_link_modules` in `CMakeLists.txt`, ensuring correct linkage during the build.